### PR TITLE
nocrypto -> mirage_crypto ; also DSA checks are superfluous now

### DIFF
--- a/lib/openpgp.ml
+++ b/lib/openpgp.ml
@@ -617,7 +617,7 @@ struct
     | Public_key_packet.RSA_privkey_asf key ->
       Logs.debug (fun m -> m "sign: signing digest with RSA key") ;
 
-      nocrypto_poly_variant_of_hash_algorithm hash_algorithm >>| fun hash ->
+      mirage_crypto_poly_variant_of_hash_algorithm hash_algorithm >>| fun hash ->
         (RSA_sig_asf { m_pow_d_mod_n =
                           Mirage_crypto_pk.Rsa.PKCS1.sign ~mask:`Yes
                           ~hash

--- a/lib/public_key_packet.ml
+++ b/lib/public_key_packet.ml
@@ -179,24 +179,17 @@ let parse_dsa_asf buf : (public_key_asf * Cs.t, 'error) result =
   consume_mpi buf >>= fun (q , buf) ->
   consume_mpi buf >>= fun (gg , buf) ->
   consume_mpi buf >>= fun (y , buf_tl) ->
-
   (* TODO validation of gg and y? *)
   (* TODO Z.numbits gg *)
-  (* TODO check y < p *)
-
-  (* TODO the public key doesn't contain the hash algo; the signature does *)
-  dsa_asf_are_valid_parameters ~p ~q ~hash_algo:SHA512 >>= fun () ->
-
-  Mirage_crypto_pk.Dsa.pub ~p ~q ~gg ~y () >>| fun pk ->
+  Mirage_crypto_pk.Dsa.pub ~fips:true ~p ~q ~gg ~y () >>| fun pk ->
   (DSA_pubkey_asf pk), buf_tl
 
 let parse_secret_dsa_asf {Mirage_crypto_pk.Dsa.p;q;gg;y} buf
   : (private_key_asf * Cs.t, [> `Msg of string ] ) result =
   (* Algorithm-Specific Fields for DSA secret keys:
      - MPI of DSA secret exponent x. *)
-  (* TODO validate parameters *)
   consume_mpi buf >>= fun (x,tl) ->
-  Mirage_crypto_pk.Dsa.priv ~x ~p ~q ~gg ~y () >>| fun sk ->
+  Mirage_crypto_pk.Dsa.priv ~fips:true ~x ~p ~q ~gg ~y () >>| fun sk ->
   DSA_privkey_asf sk, tl
 
 let parse_secret_elgamal_asf (_:'pk) buf =

--- a/lib/signature_packet.ml
+++ b/lib/signature_packet.ml
@@ -392,7 +392,7 @@ The signature was not signed by this public key.|}
       | Public_key_packet.RSA_pubkey_encrypt_or_sign_asf pub
       ), RSA_sig_asf {m_pow_d_mod_n} ->
       (* TODO validate parameters? *)
-      nocrypto_poly_variant_of_hash_algorithm t.hash_algorithm
+      mirage_crypto_poly_variant_of_hash_algorithm t.hash_algorithm
       >>= fun hash_algo ->
         let()= Logs.debug (fun m ->
           m "Trying to verify computed %a digest\n%s\n against \

--- a/lib/signature_packet.ml
+++ b/lib/signature_packet.ml
@@ -378,10 +378,8 @@ The signature was not signed by this public key.|}
                 t.algorithm_specific_data with
     | Public_key_packet.DSA_pubkey_asf key, DSA_sig_asf {r;s;} ->
       Logs.debug (fun m -> m "Trying to verify a DSA signature") ;
-      dsa_asf_are_valid_parameters ~p:key.Mirage_crypto_pk.Dsa.p
-                                   ~q:key.Mirage_crypto_pk.Dsa.q
-                                   ~hash_algo:t.hash_algorithm
-      >>= fun () ->
+      dsa_good_hash ~q:key.Mirage_crypto_pk.Dsa.q
+        ~hash_algo:t.hash_algorithm >>= fun () ->
       let cs_r = cs_of_mpi_no_header r |> Cs.to_cstruct in
       let cs_s = cs_of_mpi_no_header s |> Cs.to_cstruct in
       e_true `Invalid_signature

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -609,7 +609,7 @@ let e_log_ptime_plus_span_is_smaller err_cb (base,span) current_time =
   >>= fun comp ->
   true_or_error (-1 = comp) err_cb
 
-let nocrypto_poly_variant_of_hash_algorithm = function
+let mirage_crypto_poly_variant_of_hash_algorithm = function
   | MD5 -> Error (`Msg "MD5 is deprecated and disabled for security reasons")
   | SHA1 -> Ok `SHA1
   | SHA224 -> Ok `SHA224
@@ -619,18 +619,14 @@ let nocrypto_poly_variant_of_hash_algorithm = function
   | RIPEMD160 -> Error (`Msg "RIPE-MD/160 not implemented")
   | Unknown_hash c ->
     error_msg (fun m -> m "can't give unimplemented hash \
-                           algorithm %d to nocrypto" (Char.code c))
-
-let nocrypto_module_of_hash_algorithm algo :
-  ((module Mirage_crypto.Hash.S),[> ]) result =
-  nocrypto_poly_variant_of_hash_algorithm algo >>| Mirage_crypto.Hash.module_of
+                           algorithm %d to mirage-crypto" (Char.code c))
 
 type digest_finalizer = unit -> Cs.t
 type digest_feeder = (Cs.t -> unit) * digest_finalizer
 
 let digest_callback hash_algo: (digest_feeder, [> `Msg of string]) result =
-  nocrypto_module_of_hash_algorithm hash_algo >>= fun m ->
-  let module H = (val (m)) in
+  mirage_crypto_poly_variant_of_hash_algorithm hash_algo >>= fun m ->
+  let module H = (val Mirage_crypto.Hash.module_of m) in
   let state = ref H.empty in
   let debug_id =
     let i = Mirage_crypto_rng.generate 4 in


### PR DESCRIPTION
see https://github.com/mirage/mirage-crypto/blob/v0.6.2/pk/dsa.ml#L10-L39 (as you noted in `dsa_asf_are_valid_parameters`), the checks are now part of the Dsa.pub and Dsa.priv constructors.